### PR TITLE
Reference LICENSE by its official OSI label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'pytoolconfig'
 dynamic = ["version"]
 description = 'Python tool configuration'
-license = 'LGPL-3.0-or-later'
+license = 'LGPL-3.0'
 dependencies = [
     "tomli>=2.0.1; python_version < \"3.11\"",
     "packaging>=22.0",


### PR DESCRIPTION
See https://opensource.org/licenses/LGPL-3.0

This helps license checkers like e.g. `piplicenses` to uniquely identify the license.